### PR TITLE
Switch VSIM to FP32 binary format

### DIFF
--- a/app/api/redis/command/vsim/command.ts
+++ b/app/api/redis/command/vsim/command.ts
@@ -1,4 +1,4 @@
-import { validateKeyName } from '@/lib/redis-server/utils'
+import { validateKeyName, vectorToFp32Buffer } from '@/lib/redis-server/utils'
 import { VsimRequestBody } from '@/lib/redis-server/api'
 
 export function validateVsimRequest(body: any): { isValid: boolean; error?: string; value?: VsimRequestBody } {
@@ -61,15 +61,11 @@ export function validateVsimRequest(body: any): { isValid: boolean; error?: stri
     }
 }
 
-export function buildVsimCommand(request: VsimRequestBody): string[][] {
-    const baseCommand = ["VSIM", request.keyName]
+export function buildVsimCommand(request: VsimRequestBody): (string | Buffer)[][] {
+    const baseCommand: (string | Buffer)[] = ["VSIM", request.keyName]
 
     if (request.searchVector) {
-        baseCommand.push(
-            "VALUES",
-            String(request.searchVector.length),
-            ...request.searchVector.map(String)
-        )
+        baseCommand.push("FP32", vectorToFp32Buffer(request.searchVector))
     } else if (request.searchElement) {
         baseCommand.push("ELE", request.searchElement)
     }

--- a/app/api/redis/command/vsim/route.ts
+++ b/app/api/redis/command/vsim/route.ts
@@ -34,7 +34,9 @@ export async function POST(request: Request) {
             return NextResponse.json({ command })
         }
 
-        const commandStr = command[0].join(' ')
+        const commandStr = command[0]
+            .map((arg) => (arg instanceof Buffer ? '<binary>' : String(arg)))
+            .join(' ')
         const redisResult = await RedisConnection.withClient(redisUrl, async (client) => {
             return await client.sendCommand(command[0])
         })

--- a/lib/redis-server/utils.ts
+++ b/lib/redis-server/utils.ts
@@ -92,3 +92,12 @@ export function validateVector(vector: unknown): { isValid: boolean; error?: str
 export function validateElement(element: string | undefined): boolean {
     return typeof element === 'string' && element.length > 0
 }
+
+// Helper to encode an array of numbers into a Buffer of FP32 little-endian values
+export function vectorToFp32Buffer(vector: number[]): Buffer {
+    const buffer = Buffer.allocUnsafe(vector.length * 4)
+    for (let i = 0; i < vector.length; i++) {
+        buffer.writeFloatLE(vector[i], i * 4)
+    }
+    return buffer
+}


### PR DESCRIPTION
## Summary
- add helper to encode vectors to FP32 Buffer
- build VSIM commands with `FP32` payloads instead of `VALUES`
- handle binary arguments when building the command string for logging

## Testing
- `npm run lint`